### PR TITLE
fix: Error invalid type: floating point `7.6`

### DIFF
--- a/src-tauri/src/dto/tenor_response.rs
+++ b/src-tauri/src/dto/tenor_response.rs
@@ -19,7 +19,7 @@ pub struct MediaFormats {
 #[derive(Serialize, Deserialize)]
 pub struct GifFields {
     pub url: String,
-    pub duration: u32,
+    pub duration: f32,
     pub dims: Vec<u32>,
     pub size: u32
 }


### PR DESCRIPTION
```rs
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Decode, source: Error("invalid type: floating point `7.6`, expected u32", line: 2894, column: 25) }', src\client\tenor_client.rs:27:62

```

